### PR TITLE
Finding reason for random fails in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: javascript
 node_js:
   - 12.7
+
+before_script:
+  - npm update

--- a/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
+++ b/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
@@ -331,7 +331,7 @@ describe('CollapsibleTagsinput', () => {
 
 
       // TODO: Will fix this in other MR
-      xit('should update count when tags are added ' +
+      it('should update count when tags are added ' +
          'and input is on multiple lines', async () => {
         await page.click('#add-tag')
         await page.click('#add-tag')

--- a/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
+++ b/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
@@ -331,7 +331,7 @@ describe('CollapsibleTagsinput', () => {
 
 
       // TODO: Will fix this in other MR
-      it('should update count when tags are added ' +
+      xit('should update count when tags are added ' +
          'and input is on multiple lines', async () => {
         await page.click('#add-tag')
         await page.click('#add-tag')


### PR DESCRIPTION
Builds in Travis is failing randomly. Eg.
- https://travis-ci.org/github/JankariTech/avocode-email-tagsinput/builds/678526556
- https://travis-ci.org/github/JankariTech/avocode-email-tagsinput/builds/678486034

The failing scenarios are:
- CollapsibleTagsinput › counter › multiple tags › should update count when tags are added and input is on multiple lines
- TagsInput › selection › should select the whole text using mouse
- TagsInput › selection › should select the whole text and tag nodes using mouse drag
- Avocode Email Tags Input › Basic Email Tags Input › user typing › should insert text