### PR TITLE
Special page in playground package for testing unique and basic emal tags

### DIFF
--- a/packages/avocode-email-tagsinput/package-lock.json
+++ b/packages/avocode-email-tagsinput/package-lock.json
@@ -4,6 +4,16 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@avocode/better-react-tagsinput": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@avocode/better-react-tagsinput/-/better-react-tagsinput-2.0.0.tgz",
+			"integrity": "sha512-o3SFZYia2eHyXcmJHGWNRnaU+VkFUpbzehHMS/CJmv+y8kkhK6vGRkVSf7Xl5VL9kjfu8MCKOt7YF9ZRzuLulQ==",
+			"requires": {
+				"classnames": "^2.2.6",
+				"slate": "^0.47.0",
+				"slate-react": "^0.22.0"
+			}
+		},
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -485,9 +495,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-			"integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+			"version": "5.7.4",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
 			"dev": true
 		},
 		"acorn-globals": {
@@ -501,9 +511,9 @@
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-					"integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+					"version": "6.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+					"integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
 					"dev": true
 				}
 			}
@@ -1358,6 +1368,11 @@
 			"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
 			"dev": true
 		},
+		"direction": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/direction/-/direction-0.1.5.tgz",
+			"integrity": "sha1-zl15f5fib4vnvv9T99xA4cGp7Ew="
+		},
 		"discontinuous-range": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
@@ -1552,6 +1567,11 @@
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
 			"dev": true
+		},
+		"esrever": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/esrever/-/esrever-0.2.0.tgz",
+			"integrity": "sha1-lunSj08bGnZ4TNXUkOquAQ50B7g="
 		},
 		"estraverse": {
 			"version": "4.3.0",
@@ -2469,6 +2489,11 @@
 			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 			"dev": true
 		},
+		"get-document": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/get-document/-/get-document-1.0.0.tgz",
+			"integrity": "sha1-SCG85m8cJMsDMWAr5strEsTwHEs="
+		},
 		"get-func-name": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
@@ -2489,6 +2514,14 @@
 			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
 			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
 			"dev": true
+		},
+		"get-window": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/get-window/-/get-window-1.1.2.tgz",
+			"integrity": "sha512-yjWpFcy9fjhLQHW1dPtg9ga4pmizLY8y4ZSHdGrAQ1NU277MRhnGnnLPxe19X8W5lWVsCZz++5xEuNozWMVmTw==",
+			"requires": {
+				"get-document": "1"
+			}
 		},
 		"getpass": {
 			"version": "0.1.7",
@@ -2777,7 +2810,6 @@
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.0.0"
 			}
@@ -2919,6 +2951,16 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-hotkey": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-hotkey/-/is-hotkey-0.1.4.tgz",
+			"integrity": "sha512-Py+aW4r5mBBY18TGzGz286/gKS+fCQ0Hee3qkaiSmEPiD0PqFpe0wuA3l7rTOUKyeXl8Mxf3XzJxIoTlSv+kxA=="
+		},
+		"is-in-browser": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+			"integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
+		},
 		"is-number": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -2949,7 +2991,6 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"dev": true,
 			"requires": {
 				"isobject": "^3.0.1"
 			}
@@ -2996,6 +3037,11 @@
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
 		},
+		"is-window": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-window/-/is-window-1.0.2.tgz",
+			"integrity": "sha1-LIlspT25feRdPDMTOmXYyfVjSA0="
+		},
 		"is-windows": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -3023,8 +3069,12 @@
 		"isobject": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-			"dev": true
+			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+		},
+		"isomorphic-base64": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/isomorphic-base64/-/isomorphic-base64-1.0.2.tgz",
+			"integrity": "sha1-9Caq6CVpuopOxcpzrSGkSrHueAM="
 		},
 		"isstream": {
 			"version": "0.1.2",
@@ -3551,8 +3601,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"jsbn": {
 			"version": "0.1.1",
@@ -3743,8 +3792,7 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash.escape": {
 			"version": "4.0.1",
@@ -3774,7 +3822,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -3840,6 +3887,11 @@
 				"mimic-fn": "^2.0.0",
 				"p-is-promise": "^2.0.0"
 			}
+		},
+		"memoize-one": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-4.0.3.tgz",
+			"integrity": "sha512-QmpUu4KqDmX0plH4u+tf0riMc1KHE1+lw95cMrLlXQAFOx/xnBtwhZ52XJxd9X2O6kwKBqX32kmhbhlobD0cuw=="
 		},
 		"memory-fs": {
 			"version": "0.4.1",
@@ -4122,6 +4174,11 @@
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-copy": {
 			"version": "0.1.0",
@@ -4612,6 +4669,16 @@
 				"sisteransi": "^1.0.4"
 			}
 		},
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
+		},
 		"prr": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -4671,11 +4738,18 @@
 				"ret": "~0.1.10"
 			}
 		},
+		"react-immutable-proptypes": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/react-immutable-proptypes/-/react-immutable-proptypes-2.2.0.tgz",
+			"integrity": "sha512-Vf4gBsePlwdGvSZoLSBfd4HAP93HDauMY4fDjXhreg/vg6F3Fj/MXDNyTbltPC/xZKmZc+cjLu3598DdYK6sgQ==",
+			"requires": {
+				"invariant": "^2.2.2"
+			}
+		},
 		"react-is": {
 			"version": "16.12.0",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
-			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
-			"dev": true
+			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
 		},
 		"read-pkg": {
 			"version": "3.0.0",
@@ -4944,6 +5018,11 @@
 				"ajv-keywords": "^3.1.0"
 			}
 		},
+		"selection-is-backward": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/selection-is-backward/-/selection-is-backward-1.0.0.tgz",
+			"integrity": "sha1-l6VGMxiKURq6ZBn8XB+pG0Z+a+E="
+		},
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -5017,6 +5096,114 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
 			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 			"dev": true
+		},
+		"slate": {
+			"version": "0.47.9",
+			"resolved": "https://registry.npmjs.org/slate/-/slate-0.47.9.tgz",
+			"integrity": "sha512-EK4O6b7lGt+g5H9PGw9O5KCM4RrOvOgE9mPi3rzQ0zDRlgAb2ga4TdpS6XNQbrsJWsc8I1fjaSsUeCqCUhhi9A==",
+			"requires": {
+				"debug": "^3.1.0",
+				"direction": "^0.1.5",
+				"esrever": "^0.2.0",
+				"is-plain-object": "^2.0.4",
+				"lodash": "^4.17.4",
+				"tiny-invariant": "^1.0.1",
+				"tiny-warning": "^0.0.3",
+				"type-of": "^2.0.1"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
+			}
+		},
+		"slate-base64-serializer": {
+			"version": "0.2.112",
+			"resolved": "https://registry.npmjs.org/slate-base64-serializer/-/slate-base64-serializer-0.2.112.tgz",
+			"integrity": "sha512-Vo94bkCq8cbFj7Lutdh2RaM9S4WlLxnnMqZPKGUyefklUN4q2EzM/WUH7s9CIlLUH1qRfC/b0V25VJZr5XXTzA==",
+			"requires": {
+				"isomorphic-base64": "^1.0.2"
+			}
+		},
+		"slate-dev-environment": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/slate-dev-environment/-/slate-dev-environment-0.2.2.tgz",
+			"integrity": "sha512-JZ09llrRQu6JUsLJCUlGC0lB1r1qIAabAkSd454iyYBq6lDuY//Bypi3Jo8yzIfzZ4+mRLdQvl9e8MbeM9l48Q==",
+			"requires": {
+				"is-in-browser": "^1.1.3"
+			}
+		},
+		"slate-hotkeys": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/slate-hotkeys/-/slate-hotkeys-0.2.9.tgz",
+			"integrity": "sha512-y+C/s5vJEmBxo8fIqHmUcdViGwALL/A6Qow3sNG1OHYD5SI11tC2gfYtGbPh+2q0H7O4lufffCmFsP5bMaDHqA==",
+			"requires": {
+				"is-hotkey": "0.1.4",
+				"slate-dev-environment": "^0.2.2"
+			}
+		},
+		"slate-plain-serializer": {
+			"version": "0.7.11",
+			"resolved": "https://registry.npmjs.org/slate-plain-serializer/-/slate-plain-serializer-0.7.11.tgz",
+			"integrity": "sha512-vzXQ68GiHHcTUcAB6ggf2qN/sX9BoLs77SMHacp5Gkg+oHAA/NxRzRH4efDAhpiJqfJZDrA3rQySK6+Y7KAuwg=="
+		},
+		"slate-prop-types": {
+			"version": "0.5.42",
+			"resolved": "https://registry.npmjs.org/slate-prop-types/-/slate-prop-types-0.5.42.tgz",
+			"integrity": "sha512-3n3556FDs9/cyhRdDMryVB1PJvWeu+p3dx9TvHtONybud4tfulWk4r175JoVWcFZCUFGFQK7IbObUbz1MWNKCg=="
+		},
+		"slate-react": {
+			"version": "0.22.10",
+			"resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.22.10.tgz",
+			"integrity": "sha512-B2Ms1u/REbdd8yKkOItKgrw/tX8klgz5l5x6PP86+oh/yqmB6EHe0QyrYlQ9fc3WBlJUVTOL+nyAP1KmlKj2/w==",
+			"requires": {
+				"debug": "^3.1.0",
+				"get-window": "^1.1.1",
+				"is-window": "^1.0.2",
+				"lodash": "^4.1.1",
+				"memoize-one": "^4.0.0",
+				"prop-types": "^15.5.8",
+				"react-immutable-proptypes": "^2.1.0",
+				"selection-is-backward": "^1.0.0",
+				"slate-base64-serializer": "^0.2.112",
+				"slate-dev-environment": "^0.2.2",
+				"slate-hotkeys": "^0.2.9",
+				"slate-plain-serializer": "^0.7.11",
+				"slate-prop-types": "^0.5.42",
+				"slate-react-placeholder": "^0.2.9",
+				"tiny-invariant": "^1.0.1",
+				"tiny-warning": "^0.0.3"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
+			}
+		},
+		"slate-react-placeholder": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/slate-react-placeholder/-/slate-react-placeholder-0.2.9.tgz",
+			"integrity": "sha512-YSJ9Gb4tGpbzPje3eNKtu26hWM8ApxTk9RzjK+6zfD5V/RMTkuWONk24y6c9lZk0OAYNZNUmrnb/QZfU3j9nag=="
 		},
 		"snapdragon": {
 			"version": "0.8.2",
@@ -5405,6 +5592,16 @@
 			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 			"dev": true
 		},
+		"tiny-invariant": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+			"integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+		},
+		"tiny-warning": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-0.0.3.tgz",
+			"integrity": "sha512-r0SSA5Y5IWERF9Xh++tFPx0jITBgGggOsRLDWWew6YRw/C2dr4uNO1fw1vanrBmHsICmPyMLNBZboTlxUmUuaA=="
+		},
 		"tmpl": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -5507,6 +5704,11 @@
 			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
 			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
 			"dev": true
+		},
+		"type-of": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/type-of/-/type-of-2.0.1.tgz",
+			"integrity": "sha1-5yoXQYllaOn2KDeNgW1pEvfyOXI="
 		},
 		"union-value": {
 			"version": "1.0.1",

--- a/packages/avocode-email-tagsinput/test/e2e/avocode-email-tagsinput.spec.js
+++ b/packages/avocode-email-tagsinput/test/e2e/avocode-email-tagsinput.spec.js
@@ -1,0 +1,139 @@
+import puppeteer from 'puppeteer'
+import { expect } from 'chai'
+import {
+  URLRoot,
+  tagsInputFieldSelector,
+  getAnchorAndFocus,
+  addEmailTag,
+  getTagNodes, getInputText,
+} from './test-utils'
+
+describe('Avocode Email Tags Input', () => {
+  let browser
+  let page
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch(browserOptions)
+  })
+
+  afterEach(async () => {
+    await page.close()
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  describe('Basic Email Tags Input', () => {
+    beforeEach(async () => {
+      page = await browser.newPage()
+      await page.goto(URLRoot)
+    })
+
+    it('should render editor', async () => {
+      const editor = await page.waitForSelector(tagsInputFieldSelector)
+
+      expect(editor).to.exist
+    })
+
+    describe('user typing', () => {
+      it('should insert text', async () => {
+        await page.click(tagsInputFieldSelector)
+        await page.type(tagsInputFieldSelector, 'abcd')
+        const text = await getInputText(page)
+
+        expect(text).to.equal('abcd')
+      })
+
+      it('should delete text with backspace', async () => {
+        await page.click(tagsInputFieldSelector)
+        await page.type(tagsInputFieldSelector, 'abcd')
+        await page.keyboard.press('Backspace')
+        const text = await getInputText(page)
+
+        expect(text).to.equal('abc')
+      })
+
+      it('should delete text with delete', async () => {
+        await page.click(tagsInputFieldSelector)
+        await page.type(tagsInputFieldSelector, 'abcd')
+        await page.keyboard.press('ArrowLeft')
+        await page.keyboard.press('Delete')
+        const text = await getInputText(page)
+
+        expect(text).to.equal('abc')
+      })
+
+      it('should navigate one char left', async () => {
+        await page.click(tagsInputFieldSelector)
+        await page.type(tagsInputFieldSelector, 'abcd')
+        await page.keyboard.press('ArrowLeft')
+        const [ anchorOffset ] = await getAnchorAndFocus(page)
+
+        expect(anchorOffset).to.equal(3)
+      })
+    })
+
+    it('should not be allowed to add invalid email as a tag', async () => {
+      await addEmailTag(page, 'testemail@ex.11')
+      const tagNodes = await getTagNodes(page)
+
+      expect(tagNodes).to.have.length(0)
+    })
+
+    it('should be allowed to add valid email as a tag', async () => {
+      await addEmailTag(page, 'testEmail@example.com')
+      const tagNodes = await getTagNodes(page)
+
+      expect(tagNodes).to.have.length(1)
+    })
+
+    describe('user can add new tag typing valid email and hitting comma, enter or space', () => {
+      const validEmailTag = 'test@ex.com'
+
+      it('should be possible to add an email tag hitting Comma key', async () => {
+        await addEmailTag(page, validEmailTag, 'Comma')
+        const tagNodes = await getTagNodes(page)
+
+        expect(tagNodes).to.have.length(1)
+      })
+
+      it('should be possible to add an email tag hitting Enter key', async () => {
+        await addEmailTag(page, validEmailTag, 'Enter')
+        const tagNodes = await getTagNodes(page)
+
+        expect(tagNodes).to.have.length(1)
+      })
+
+      it('should be possible to add an email tag hitting Space key', async () => {
+        await addEmailTag(page, validEmailTag, 'Space')
+        const tagNodes = await getTagNodes(page)
+
+        expect(tagNodes).to.have.length(1)
+      })
+    })
+  })
+
+  describe('Unique Email Tags Input', () => {
+    beforeEach(async () => {
+      page = await browser.newPage()
+      await page.goto(`${URLRoot}/unique`)
+    })
+
+    it('should be allowed to add unique email tags', async () => {
+      await addEmailTag(page, 'foo@example.com')
+      await addEmailTag(page, 'bar@example.com')
+      const tagNodes = await getTagNodes(page)
+
+      expect(tagNodes).to.have.length(2)
+    })
+
+    it('should not be allowed to add same email tag again', async () => {
+      await addEmailTag(page, 'foo@example.com')
+      await addEmailTag(page, 'foo@example.com')
+      const tagNodes = await getTagNodes(page)
+      
+      expect(tagNodes).to.have.length(1)
+    })
+  })
+})

--- a/packages/avocode-email-tagsinput/test/e2e/avocode-email-tagsinput.spec.js
+++ b/packages/avocode-email-tagsinput/test/e2e/avocode-email-tagsinput.spec.js
@@ -27,7 +27,7 @@ describe('Avocode Email Tags Input', () => {
   describe('Basic Email Tags Input', () => {
     beforeEach(async () => {
       page = await browser.newPage()
-      await page.goto(URLRoot)
+      await page.goto(`${URLRoot}/test-email-tagsinput`)
     })
 
     it('should render editor', async () => {
@@ -117,7 +117,7 @@ describe('Avocode Email Tags Input', () => {
   describe('Unique Email Tags Input', () => {
     beforeEach(async () => {
       page = await browser.newPage()
-      await page.goto(`${URLRoot}/unique`)
+      await page.goto(`${URLRoot}/test-unique-email-tagsinput`)
     })
 
     it('should be allowed to add unique email tags', async () => {
@@ -132,7 +132,7 @@ describe('Avocode Email Tags Input', () => {
       await addEmailTag(page, 'foo@example.com')
       await addEmailTag(page, 'foo@example.com')
       const tagNodes = await getTagNodes(page)
-      
+
       expect(tagNodes).to.have.length(1)
     })
   })

--- a/packages/avocode-email-tagsinput/test/e2e/test-utils.js
+++ b/packages/avocode-email-tagsinput/test/e2e/test-utils.js
@@ -1,0 +1,54 @@
+const tagsInputFieldSelector = '.tagsinput'
+const tagSubmitKeys = [ 'Comma', 'Enter', 'Space' ]
+const URLRoot = isDevelopment
+  ? 'http://localhost:8080/#/avocode-email-tagsinput'
+  : 'https://avocode-email-tagsinput.surge.sh/#/avocode-email-tagsinput'
+
+const getInputText = async (page, inputFieldSelector = tagsInputFieldSelector) => {
+  const text = await page.evaluate((selector) => {
+    const editor = document.querySelector(selector)
+
+    return editor.textContent
+  }, inputFieldSelector)
+
+  return text.trim()
+}
+
+const getTagNodes = async (page, inputFieldSelector = tagsInputFieldSelector) => {
+  return page.evaluate((selector) => {
+    const editor = document.querySelector(selector)
+    const tagNodes = editor.querySelectorAll('.tag')
+
+    return Array.from(tagNodes)
+      .map((node) => {
+        return {
+          text: node.textContent.trim(),
+          className: node.className,
+          html: node.innerHTML,
+        }
+      })
+  }, inputFieldSelector)
+}
+
+const getAnchorAndFocus = async (page) => {
+  return page.evaluate(() => {
+    const selection = window.getSelection()
+
+    return [ selection.anchorOffset, selection.focusOffset ]
+  })
+}
+
+const addEmailTag = async (page, emailTag, submitKey = 'Comma') => {
+  await page.click(tagsInputFieldSelector)
+  await page.type(tagsInputFieldSelector, emailTag)
+  await page.keyboard.press(submitKey)
+}
+
+export {
+  URLRoot,
+  tagsInputFieldSelector,
+  addEmailTag,
+  getTagNodes,
+  getInputText,
+  getAnchorAndFocus,
+}

--- a/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
+++ b/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
@@ -330,7 +330,8 @@ describe('CollapsibleTagsinput', () => {
       })
 
 
-      it('should update count when tags are added ' +
+      // TODO: Will fix this in other MR
+      xit('should update count when tags are added ' +
          'and input is on multiple lines', async () => {
         await page.click('#add-tag')
         await page.click('#add-tag')

--- a/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
+++ b/packages/better-react-tagsinput/test/e2e/collapsible-tagsinput.spec.js
@@ -330,8 +330,7 @@ describe('CollapsibleTagsinput', () => {
       })
 
 
-      // TODO: Will fix this in other MR
-      xit('should update count when tags are added ' +
+      it('should update count when tags are added ' +
          'and input is on multiple lines', async () => {
         await page.click('#add-tag')
         await page.click('#add-tag')

--- a/packages/playground/components/avocode-email-tagsiput/index.js
+++ b/packages/playground/components/avocode-email-tagsiput/index.js
@@ -9,7 +9,8 @@ import Unique from './unique'
 import Collapsible from './collapsible'
 import LongInput from './long-input'
 import SubmitOnEnter from './submit-on-enter'
-
+import TestE2EEmailTags from './test-e2e-avocode-email-tagsinput'
+import TestE2EUniqueEmailTags from './test-e2e-unique-email-tagsinput'
 type Props = {
   match: {
     url: string,
@@ -42,6 +43,8 @@ export default class AvocodeEmailTagsInputView extends React.PureComponent<Props
           <Route path={`${url}/collapsible`} component={Collapsible} />
           <Route path={`${url}/long-input`} component={LongInput} />
           <Route path={`${url}/submit-on-enter`} component={SubmitOnEnter} />
+          <Route path={`${url}/test-email-tagsinput`} component={TestE2EEmailTags} />
+          <Route path={`${url}/test-unique-email-tagsinput`} component={TestE2EUniqueEmailTags} />
         </div>
       </Router>
     )

--- a/packages/playground/components/avocode-email-tagsiput/test-e2e-avocode-email-tagsinput.js
+++ b/packages/playground/components/avocode-email-tagsiput/test-e2e-avocode-email-tagsinput.js
@@ -1,0 +1,14 @@
+// @flow
+
+import React from 'react'
+import AvocodeEmailTagsInput from '@avocode/avocode-email-tagsinput'
+
+export default class TestE2EEmailTags extends React.PureComponent<{}, State> {
+  render() {
+    return (
+      <div>
+        <AvocodeEmailTagsInput />
+      </div>
+    )
+  }
+}

--- a/packages/playground/components/avocode-email-tagsiput/test-e2e-unique-email-tagsinput.js
+++ b/packages/playground/components/avocode-email-tagsiput/test-e2e-unique-email-tagsinput.js
@@ -1,0 +1,16 @@
+// @flow
+
+import React from 'react'
+import AvocodeEmailTagsInput from '@avocode/avocode-email-tagsinput'
+
+export default class TestE2EUniqueEmailTags extends React.PureComponent<{}, State> {
+  render() {
+    return (
+      <div>
+        <AvocodeEmailTagsInput
+          unique
+        />
+      </div>
+    )
+  }
+}


### PR DESCRIPTION
Special pages are made in `playground` package for testing where it might be better suited to test everything properly. In `better-react-tagsinput` E2E specs route like `/test-collapsible-tagsinput` is used for these purposes. This has been done as an improvement on the old PR.